### PR TITLE
Fix CI_SYSTEM check in check_release

### DIFF
--- a/autopub/check_release.py
+++ b/autopub/check_release.py
@@ -11,7 +11,8 @@ from base import CI_SYSTEM, RELEASE_FILE, run_process
 def check_release():
     if not os.path.exists(RELEASE_FILE):
         print("Not releasing a new version because there is no RELEASE file.")
+        
         if CI_SYSTEM == "circleci":
             run_process(["circleci", "step", "halt"])
-    elif CI_SYSTEM == "travis":
-        print("true")
+        elif CI_SYSTEM == "travis":
+            print("true")


### PR DESCRIPTION
I think the `elif` here was meant to be inline with the `circleci` check, not the path exist check?