### PR TITLE
Support building and publishing via setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AutoPub enables project maintainers to release new package versions to PyPI by m
 
 ## Environment
 
-AutoPub is intended for use with continuous integration (CI) systems and currently supports CircleCI. Projects used with AutoPub are assumed to be managed via [Poetry][]. Support for other CI and build systems is planned and contributions adding such support would be welcome.
+AutoPub is intended for use with continuous integration (CI) systems such as [CircleCI][] or [Travis CI][]. Projects used with AutoPub can be published via [Poetry][] or [setuptools][]. Contributions that add support for other CI and build systems are welcome.
 
 ## Configuration
 
@@ -35,8 +35,17 @@ The following `autopub` sub-commands can be used as steps in your CI flows:
 
 * `autopub check`: Check whether release file exists.
 * `autopub prepare`: Update version strings and add entry to changelog.
+* `autopub build`: Build the project.
 * `autopub commit`: Add, commit, and push incremented version and changelog changes.
 * `autopub githubrelease`: Create a new release on GitHub.
+* `autopub publish`: Publish a new release.
+
+For systems such as Travis CI in which only one deployment step is permitted, there is a single command that runs the above steps in sequence:
+
+* `autopub deploy`: Run `prepare`, `build`, `commit`, `githubrelease`, and `publish` in one invocation.
 
 
+[CircleCI]: https://circleci.com
+[Travis CI]: https://travis-ci.org
 [Poetry]: https://poetry.eustace.io
+[setuptools]: https://setuptools.readthedocs.io/

--- a/autopub/autopub.py
+++ b/autopub/autopub.py
@@ -4,11 +4,13 @@ import sys
 
 sys.path.append(os.path.dirname(__file__))  # noqa
 
+from build_release import build_release
 from check_release import check_release
-from prepare_release import prepare_release
 from commit_release import git_commit_and_push
 from create_github_release import create_github_release
 from deploy_release import deploy_release
+from prepare_release import prepare_release
+from publish_release import publish_release
 
 
 def check(arguments):
@@ -19,12 +21,20 @@ def prepare(arguments):
     prepare_release()
 
 
+def build(arguments):
+    build_release()
+
+
 def commit(arguments):
     git_commit_and_push()
 
 
 def githubrelease(arguments):
     create_github_release()
+
+
+def publish(arguments):
+    publish_release()
 
 
 def deploy(arguments):
@@ -48,11 +58,17 @@ def parse_arguments():
     prepare_parser = subparsers.add_parser("prepare")
     prepare_parser.set_defaults(func=prepare)
 
+    build_parser = subparsers.add_parser("build")
+    build_parser.set_defaults(func=build)
+
     commit_parser = subparsers.add_parser("commit")
     commit_parser.set_defaults(func=commit)
 
     githubrelease_parser = subparsers.add_parser("githubrelease")
     githubrelease_parser.set_defaults(func=githubrelease)
+
+    publish_parser = subparsers.add_parser("publish")
+    publish_parser.set_defaults(func=publish)
 
     deploy_parser = subparsers.add_parser("deploy")
     deploy_parser.set_defaults(func=deploy)

--- a/autopub/base.py
+++ b/autopub/base.py
@@ -86,6 +86,18 @@ VERSION_STRINGS = dict_get(
     config, ["tool", "autopub", "version-strings"], default=[]
 )
 
+PYPI_URL = dict_get(
+    config, ["tool", "autopub", "pypi-url"], default="https://pypi.org/"
+)
+
+BUILD_SYSTEM = dict_get(config, ["tool", "autopub", "build-system"])
+if not BUILD_SYSTEM:
+    build_requires = dict_get(config, ["build-system", "requires"])
+    if "poetry" in build_requires:
+        BUILD_SYSTEM = "poetry"
+    elif "setuptools" in build_requires:
+        BUILD_SYSTEM = "setuptools"
+
 # Git configuration
 
 GIT_USERNAME = dict_get(config, ["tool", "autopub", "git-username"])

--- a/autopub/build_release.py
+++ b/autopub/build_release.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))  # noqa
+
+from base import BUILD_SYSTEM, run_process
+
+if BUILD_SYSTEM == "poetry":
+    build_cmd = ["poetry", "build"]
+else:
+    build_cmd = ["python", "setup.py", "sdist", "bdist_wheel"]
+
+
+def build_release():
+    run_process(build_cmd)

--- a/autopub/deploy_release.py
+++ b/autopub/deploy_release.py
@@ -3,17 +3,16 @@ import sys
 
 sys.path.append(os.path.dirname(__file__))  # noqa
 
-from base import run_process
+from build_release import build_release
 from create_github_release import create_github_release
-from prepare_release import prepare_release
 from commit_release import git_commit_and_push
+from prepare_release import prepare_release
+from publish_release import publish_release
 
 
 def deploy_release():
     prepare_release()
-    run_process(["poetry", "build"])
+    build_release()
     git_commit_and_push()
     create_github_release()
-    run_process(
-        ["poetry", "publish", "-u", "$PYPI_USERNAME", "-p", "$PYPI_PASSWORD"]
-    )
+    publish_release()

--- a/autopub/publish_release.py
+++ b/autopub/publish_release.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))  # noqa
+
+from base import BUILD_SYSTEM, PYPI_URL, run_process
+
+subprocess_output_encoding = "ascii"
+
+if BUILD_SYSTEM == "poetry":
+    pub_cmd = ["poetry", "publish", "-u", "$PYPI_USERNAME", "-p", "$PYPI_PASSWORD"]
+else:
+    pub_cmd = ["twine", "upload", "--repository-url", PYPI_URL, "dist/*"]
+    subprocess_output_encoding = "utf-8"
+
+
+def publish_release():
+    run_process(pub_cmd, subprocess_output_encoding)


### PR DESCRIPTION
The all-in-one `deploy_release()` function now supports build and publish commands as arguments in order to allow for building via `setuptools` and publishing packages via Twine to a configurable PyPI URL.

Assumes CI configuration is utilized to install Twine and set `TWINE_USERNAME` + `TWINE_PASSWORD` environment variables.