### PR TITLE
Make github_release truly optional

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Ensure AutoPub can be used without installing `github_release`

--- a/autopub/create_github_release.py
+++ b/autopub/create_github_release.py
@@ -3,8 +3,6 @@ import sys
 
 sys.path.append(os.path.dirname(__file__))  # noqa
 
-from github_release import gh_release_create
-
 from base import (
     run_process,
     check_exit_code,
@@ -18,6 +16,12 @@ from base import (
 
 
 def create_github_release():
+    try:
+        from github_release import gh_release_create
+    except ModuleNotFoundError:
+        print("Cannot create GitHub release due to missing dependency: github_release")
+        sys.exit(1)
+
     configure_git()
     version = get_project_version()
     tag = f"{TAG_PREFIX}{version}"


### PR DESCRIPTION
While listed as an optional dependency in pyproject.toml, `github_release`
had to be installed in order to invoke AutoPub without a fatal error,
making the dependency, in practice, quite mandatory.

This restores the original optional intent. Now, the import only occurs
if the relevant function is called, and a helpful error message is
returned if the function's dependency is absent.

Fixes #5