### PR TITLE
Add support to publish package on a s3 bucket with s3pypi tool

### DIFF
--- a/autopub/base.py
+++ b/autopub/base.py
@@ -118,7 +118,11 @@ GIT_EMAIL = dict_get(config, ["tool", "autopub", "git-email"])
 
 
 def run_process(popenargs, encoding="utf-8"):
-    return subprocess.check_output(popenargs).decode(encoding).strip()
+    try:
+        return subprocess.check_output(popenargs).decode(encoding).strip()
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+        sys.exit(1)
 
 
 def git(popenargs):

--- a/autopub/base.py
+++ b/autopub/base.py
@@ -99,6 +99,18 @@ if not BUILD_SYSTEM:
     elif "setuptools" in build_requires:
         BUILD_SYSTEM = "setuptools"
 
+S3PYPI_COMMAND = dict_get(
+    config, ["tool", "autopub", "s3pypi-command"], default=""
+)
+
+if S3PYPI_COMMAND:
+    try:
+        import s3pypi
+    except ModuleNotFoundError:
+        print("Seems you configured s3pypi command but it is not installed...")
+        sys.exit(1)
+
+
 # Git configuration
 
 GIT_USERNAME = dict_get(config, ["tool", "autopub", "git-username"])

--- a/autopub/publish_release.py
+++ b/autopub/publish_release.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.append(os.path.dirname(__file__))  # noqa
 
-from base import BUILD_SYSTEM, PYPI_URL, run_process
+from base import BUILD_SYSTEM, PYPI_URL, S3PYPI_COMMAND, run_process
 
 poetry_pub = ["poetry", "publish", "-u", "$PYPI_USERNAME", "-p", "$PYPI_PASSWORD"]
 
@@ -17,6 +17,8 @@ if BUILD_SYSTEM == "poetry":
 else:
     pub_cmd = twine_pub
 
+if S3PYPI_COMMAND:
+    pub_cmd = S3PYPI_COMMAND.split()
 
 def publish_release():
     run_process(pub_cmd)


### PR DESCRIPTION
I just write a draft for s3 support!

Basically, I added another configuration in the `pyproject.toml` file under the `autopub` tool configuration called `s3pypi-command` that is a string with the complete command to upload the package on s3. Something like `s3pypi --bucket mypackage --private --region myregion --dist-path somewhere/dist` 
if there is that configuration it will execute it instead of call `poetry publish ...`