### PR TITLE
Set minimum Python version to 3.6

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 Release type: patch
 
-Add support for python >= 3.6
+Change minimum Python version from 3.7 to 3.6

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Add support for python >= 3.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 keywords = ["automatic", "packaging", "publish", "release", "version"]
 
 [tool.poetry.dependencies]
-python = ">=3.6"
+python = "^3.6"
 tomlkit = "^0.5.5"
 githubrelease = {version = "^1.5.8",optional = true}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 keywords = ["automatic", "packaging", "publish", "release", "version"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.6"
 tomlkit = "^0.5.5"
 githubrelease = {version = "^1.5.8",optional = true}
 


### PR DESCRIPTION
This little change should fix #13 
Looking at the code it doesn't seem to me that there is any syntax that requires python 3.7 only... isn't it?
