### PR TITLE
Add documentation tooling, structure, and base set of docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+docs/_build
 poetry.lock

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,30 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# Full list of options can be found in the Sphinx documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+
+# -- Project Information -----------------------------------------------------
+
+project = "AutoPub"
+copyright = "Justin Mayer"
+author = "Justin Mayer"
+
+
+# -- General Configuration ---------------------------------------------------
+
+extensions = [
+    "myst_parser",
+]
+
+templates_path = ["_templates"]
+
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML Output -------------------------------------------------
+
+html_theme = "furo"
+html_title = project
+
+html_static_path = ["_static"]

--- a/docs/configure/index.md
+++ b/docs/configure/index.md
@@ -1,0 +1,7 @@
+# Configuration
+
+This section covers documentation about configuring projects for automatic package publication via AutoPub.
+
+```{toctree}
+settings.md
+```

--- a/docs/configure/settings.md
+++ b/docs/configure/settings.md
@@ -1,0 +1,50 @@
+# Settings
+
+Configuration settings are read from the `[tool.autopub]` section of the project’s [`pyproject.toml`][] file, which you should add before customizing your configuration via the settings below.
+
+## Required Configuration Settings
+
+**The following configuration settings are required:**
+
+`git-username`
+:  Name of the user who will be credited in automated Git commits.
+
+`git-email`
+:  Email address for above user, to be used for automated Git commits.
+
+## Optional Configuration Settings
+
+**The following configuration settings are optional, with default values shown in parentheses:**
+
+`project-name`
+:  The name of the project. (`tool.poetry.name`)
+
+`append-github-contributor`
+:  Append GitHub PR contributor’s name to the changelog entry. (`False`)
+
+`release-file`
+:  Name of the release file AutoPub will use as its trigger. (`"RELEASE.md"`)
+
+`changelog-file`
+:  Changelog file name, to which AutoPub will append entries. (`"CHANGELOG.md"`)
+
+`changelog-header`
+:  Characters used to denote the changelog file’s top-level header. (`"========="`)
+
+`version-header`
+:  Character that AutoPub will use as secondary-level version headers. (`"-"`)
+
+`version-strings`
+:  File paths (relative to project root) of other files that contain version strings that should be incremented in addition to the [`pyproject.toml`][] file. (`[]`)
+
+`tag-prefix`
+:  String to prepend to version numbers — e.g., `"v"` for `v2.0`-style tags. (`""`)
+
+`pypi-url`
+:  Publish packages to this PyPI URL, used for Setuptools builds only (`""`)
+
+`build-system`
+:  Specify whether `poetry` or `setuptools` will be used for project builds (`build-system.requires`)
+
+
+[`pyproject.toml`]: https://www.python.org/dev/peps/pep-0518/#specification

--- a/docs/develop/contributing.md
+++ b/docs/develop/contributing.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Contributions are welcome and much appreciated. Every little bit helps. You can contribute by improving the documentation, adding missing features, and fixing bugs. You can also help out by reviewing and commenting on [existing issues][].
+
+## Development Environment
+
+AutoPub is built with [Poetry][], so if you don’t already have it installed, the first step is to install it by following the [Poetry Installation Documentation][].
+
+Once [Poetry][] is installed, follow the steps below to install AutoPub for development:
+
+```shell
+git clone https://github.com/autopub/autopub
+cd autopub
+poetry install
+```
+
+## Building the Documentation
+
+AutoPub’s documentation is found in `docs/`. Build the documentation via:
+
+```shell
+poetry run invoke docbuild
+```
+
+To build and serve the documentation in one step, run the following command and then open http://localhost:8000 in your browser:
+
+```shell
+poetry run invoke docserve
+```
+
+When you make changes to the documentation, it should be automatically re-built after a few moments, and the browser window should automatically refresh and display your changes (as long as there were no build errors). If you don’t see the expected changes, switch back to your terminal console and see if there were any build errors.
+
+
+[existing issues]: https://github.com/autopub/autopub/issues
+[Poetry]: https://python-poetry.org/
+[Poetry Installation Documentation]: https://python-poetry.org/docs/master/#installation

--- a/docs/develop/index.md
+++ b/docs/develop/index.md
@@ -1,0 +1,7 @@
+# Contribute to AutoPub
+
+This section covers documentation about developing and maintaining the AutoPub codebase, as well as some guidelines for how you can contribute.
+
+```{toctree}
+contributing.md
+```

--- a/docs/extend/create/index.md
+++ b/docs/extend/create/index.md
@@ -1,0 +1,3 @@
+# Creating Plugins
+
+This section of the documentation covers how to create plugins for AutoPub.

--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -1,0 +1,8 @@
+# Extending
+
+AutoPub supports plugins in order to extend its core functionality.
+
+```{toctree}
+plugins/index.md
+create/index.md
+```

--- a/docs/extend/plugins/index.md
+++ b/docs/extend/plugins/index.md
@@ -1,0 +1,7 @@
+# Plugins
+
+Following is a list of plugins included with AutoPub:
+
+`trigger`
+:  Perform actions after release.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,5 +6,6 @@
 ```{toctree}
 :caption: Topic Guides
 :hidden:
+configure/index.md
 develop/index.md
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# AutoPub
+
+**AutoPub enables project maintainers to release new package versions to PyPI by merging pull requests**.
+
+
+```{toctree}
+:caption: Topic Guides
+:hidden:
+develop/index.md
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,5 +7,6 @@
 :caption: Topic Guides
 :hidden:
 configure/index.md
+extend/index.md
 develop/index.md
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,12 @@ httpx = {version = "=0.16.1", optional = true}
 [tool.poetry.dev-dependencies]
 githubrelease = "^1.5"
 
+# Tasks
+invoke = "^1.6"
+
 # Docs
 furo = "^2021.9.22"
+livereload = "^2.6"
 myst-parser = "^0.15"
 Sphinx = "^4.2"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,13 @@ httpx = {version = "=0.16.1", optional = true}
 
 [tool.poetry.dev-dependencies]
 githubrelease = "^1.5"
+
+# Docs
+furo = "^2021.9.22"
+myst-parser = "^0.15"
+Sphinx = "^4.2"
+
+# Linting
 black = {version = "^19.3b0", allow-prereleases = true}
 flake8 = "^3.8"
 flake8-black = "^0.2"

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,22 @@
+import os
+
+from invoke import task
+
+DOCS_PORT = os.environ.get("DOCS_PORT", 8000)
+
+
+@task
+def docbuild(c):
+    """Build documentation"""
+    c.run("sphinx-build -W docs docs/_build")
+
+
+@task(docbuild)
+def docserve(c):
+    """Serve docs at http://localhost:$DOCS_PORT/ (default port is 8000)"""
+    from livereload import Server
+
+    server = Server()
+    server.watch("docs/conf.py", lambda: docbuild(c))
+    server.watch("docs/**/*.md", lambda: docbuild(c))
+    server.serve(port=DOCS_PORT, root="docs/_build")


### PR DESCRIPTION
When I first started working on this project, I did a poor job of creating documentation at each step of the way. Other than the meager README, there isn't any guidance for newcomers to the project, and I think it's high time that we change that.

This adds documentation powered by [Sphinx](https://www.sphinx-doc.org/) and [MyST](https://myst-parser.readthedocs.io/), with documentation build automation powered by [Invoke](https://github.com/pyinvoke/invoke). In addition to that tooling, I added a very bare-bones set of documentation encompassing:
- how to build the documentation
- what the `pyproject`-based configuration settings are
- a stub section for plugins that we can expand upon as we add plugin capabilities to the project

As it stands now, there is nothing in this PR that publishes this documentation on the web. I'd prefer that we flesh it out a bit before we foist it on the world at large. 😅 