### PR TITLE
Switch to GitHub's new environment files mechanism

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry githubrelease httpx==0.18.2 autopub
-          echo "##[set-output name=release;]$(autopub check)"
+          echo "release=$(autopub check)" >> $GITHUB_OUTPUT
       - name: Publish
         if: ${{ steps.check_release.outputs.release=='' }}
         env:


### PR DESCRIPTION
[GitHub has depreciated the set-output command](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and will remove support for it in a few month, so this commit implements the new, recommended approach.