### PR TITLE
Vendor `githubrelease`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,6 @@
 CHANGELOG
 =========
 
-Unreleased
------------
-
-* vendor [githubrelease](https://github.com/scikit-build/github-release) via [PR TBD](https://github.com/autopub/autopub/pull/TBD)
-* drop support for Python 3.7
-
 0.3.0 - 2023-06-07
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+Unreleased
+-----------
+
+* vendor [githubrelease](https://github.com/scikit-build/github-release) via [PR TBD](https://github.com/autopub/autopub/pull/TBD)
+* drop support for Python 3.7
+
 0.3.0 - 2023-06-07
 ------------------
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+* Pin `githubrelease` dependency to specific Git rev hash
+* Drop support for Python 3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ classifiers = [
 "Issue Tracker" = "https://github.com/autopub/autopub/issues"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.8.1,<4.0"
 tomlkit = ">= 0.5, < 2.0"
-githubrelease = {version = "^1.5.9", optional = true}
+githubrelease = {optional = true, git = "https://github.com/scikit-build/github-release.git", rev = "e80cbe4"}
 httpx = {version = "=0.16.1", optional = true}
 build = "^0.10.0"
 twine = "^4.0.2"


### PR DESCRIPTION
(As a drive-by, this also drops 3.7 support, which is EOL and out of the supported bounds of githubrelease)

Rather than "Vendor" directly, this is locking based on the git repo URL and a specific ref, which is the tip of the `master` branch as of Feb 5 2024.

This can and should be reset to the next formal release that includes our needed patches.

Fixes #42 