### PR TITLE
Don't relative-import the vendored `githubrelease`

### DIFF
--- a/autopub/create_github_release.py
+++ b/autopub/create_github_release.py
@@ -18,7 +18,7 @@ from base import (
 
 def create_github_release():
     try:
-        from .vendor.github_release import gh_asset_upload, gh_release_create
+        from autopub.vendor.github_release import gh_asset_upload, gh_release_create
     except ModuleNotFoundError:
         print("Cannot create GitHub release due to missing dependency: github_release")
         sys.exit(1)


### PR DESCRIPTION
I'm a bit surprised this is necessary, but I've confirmed it works

I've confirmed this by running autopub locally (but don't rely on that, because I did that last time, too :/)