### PR TITLE
v1 fixes and improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           curl -sSL https://pdm.fming.dev/install-pdm.py | python3 -
 
       - name: Install dependencies
-        run: uv sync 
+        run: uv sync
 
       - name: Run tests
         run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -10,13 +10,46 @@ AutoPub is intended for use with continuous integration (CI) systems such as [Gi
 
 ## Configuration
 
-AutoPub settings can be configured via the `[tool.autopub]` table in the target project’s `pyproject.toml` file. Required settings include Git username and email address:
+AutoPub settings can be configured via the `[tool.autopub]` table in the target project's `pyproject.toml` file or via environment variables.
+
+### Git Configuration
+
+You can configure the git username and email used for release commits in three ways:
+
+#### 1. Via pyproject.toml (recommended for project-specific settings)
+
+```toml
+[tool.autopub.plugin_config.git]
+git-username = "Your Name"
+git-email = "your_email@example.com"
+```
+
+#### 2. Via environment variables (recommended for CI/CD)
+
+```bash
+export AUTOPUB_GIT_USERNAME="release-bot[bot]"
+export AUTOPUB_GIT_EMAIL="123456+release-bot[bot]@users.noreply.github.com"
+```
+
+Environment variables take precedence over pyproject.toml configuration.
+
+#### 3. Default values
+
+If neither environment variables nor pyproject.toml configuration is provided, autopub will use:
+- Username: `autopub`
+- Email: `autopub@autopub`
+
+### Legacy Configuration
+
+For backward compatibility, the old configuration format is still supported:
 
 ```toml
 [tool.autopub]
 git-username = "Your Name"
 git-email = "your_email@example.com"
 ```
+
+However, this format is deprecated and will be removed in a future release. Please migrate to the plugin_config format shown above.
 
 ## Release Files
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ git-email = "your_email@example.com"
 #### 2. Via environment variables (recommended for CI/CD)
 
 ```bash
-export AUTOPUB_GIT_USERNAME="release-bot[bot]"
-export AUTOPUB_GIT_EMAIL="123456+release-bot[bot]@users.noreply.github.com"
+export GIT_USERNAME="release-bot[bot]"
+export GIT_EMAIL="123456+release-bot[bot]@users.noreply.github.com"
 ```
 
 Environment variables take precedence over pyproject.toml configuration.

--- a/autopub/plugins/git.py
+++ b/autopub/plugins/git.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import os
+
+from pydantic import BaseModel, Field
+
 from autopub.plugins import AutopubPlugin
 from autopub.types import ReleaseInfo
 
@@ -12,14 +16,57 @@ COMMIT_TEMPLATE = """\
 """
 
 
+class GitConfig(BaseModel):
+    """Git configuration for autopub."""
+
+    git_username: str = Field(
+        default="autopub",
+        description="Git username for commits",
+        validation_alias="git-username",
+    )
+    git_email: str = Field(
+        default="autopub@autopub",
+        description="Git email for commits",
+        validation_alias="git-email",
+    )
+
+
 class GitPlugin(AutopubPlugin):
+    id = "git"
+    Config = GitConfig
+
+    def _get_git_username(self) -> str:
+        """Get git username from environment variable or config."""
+        env_value = os.environ.get("AUTOPUB_GIT_USERNAME")
+        if env_value:
+            return env_value
+
+        if self._config:
+            return self.config.git_username  # type: ignore
+
+        return "autopub"
+
+    def _get_git_email(self) -> str:
+        """Get git email from environment variable or config."""
+        env_value = os.environ.get("AUTOPUB_GIT_EMAIL")
+        if env_value:
+            return env_value
+
+        if self._config:
+            return self.config.git_email  # type: ignore
+
+        return "autopub@autopub"
+
     def post_publish(self, release_info: ReleaseInfo) -> None:
         assert release_info.version is not None
 
         tag_name = release_info.version
 
-        self.run_command(["git", "config", "--global", "user.email", "autopub@autopub"])
-        self.run_command(["git", "config", "--global", "user.name", "autopub"])
+        git_email = self._get_git_email()
+        git_username = self._get_git_username()
+
+        self.run_command(["git", "config", "--global", "user.email", git_email])
+        self.run_command(["git", "config", "--global", "user.name", git_username])
 
         self.run_command(["git", "tag", tag_name])
 

--- a/autopub/plugins/git.py
+++ b/autopub/plugins/git.py
@@ -37,7 +37,7 @@ class GitPlugin(AutopubPlugin):
 
     def _get_git_username(self) -> str:
         """Get git username from environment variable or config."""
-        env_value = os.environ.get("AUTOPUB_GIT_USERNAME")
+        env_value = os.environ.get("GIT_USERNAME")
         if env_value:
             return env_value
 
@@ -48,7 +48,7 @@ class GitPlugin(AutopubPlugin):
 
     def _get_git_email(self) -> str:
         """Get git email from environment variable or config."""
-        env_value = os.environ.get("AUTOPUB_GIT_EMAIL")
+        env_value = os.environ.get("GIT_EMAIL")
         if env_value:
             return env_value
 

--- a/autopub/plugins/github.py
+++ b/autopub/plugins/github.py
@@ -61,7 +61,7 @@ class GithubConfig(BaseModel):
 
         ```markdown
         ---
-        release-type: patch
+        release type: patch
         ---
 
         Description of the changes, ideally with some examples, if adding a new feature.

--- a/autopub/plugins/github.py
+++ b/autopub/plugins/github.py
@@ -326,12 +326,17 @@ class GithubPlugin(AutopubPlugin):
             return
 
         contributors = self._get_pr_contributors()
-        contributor_line = f"This release was contributed by @{contributors['pr_author']} in {self.pull_request.html_url}"
+        # Use markdown links for CHANGELOG
+        pr_author_link = f"[@{contributors['pr_author']}](https://github.com/{contributors['pr_author']})"
+        pr_link = f"[#{self.pull_request.number}]({self.pull_request.html_url})"
+        contributor_line = (
+            f"This release was contributed by {pr_author_link} in {pr_link}"
+        )
         release_info.additional_release_notes.append(contributor_line)
 
         if contributors["additional_contributors"]:
             additional_contributors = [
-                f"@{contributor}"
+                f"[@{contributor}](https://github.com/{contributor})"
                 for contributor in contributors["additional_contributors"]
             ]
             release_info.additional_release_notes.append(

--- a/autopub/plugins/github.py
+++ b/autopub/plugins/github.py
@@ -372,7 +372,7 @@ class GithubPlugin(AutopubPlugin):
             return message
 
         contributors = self._get_pr_contributors()
-        message += f"\nThis release was contributed by @{contributors['pr_author']} in {self.pull_request.html_url}"
+        message += f"\n\nThis release was contributed by @{contributors['pr_author']} in {self.pull_request.html_url}"
 
         if contributors["additional_contributors"]:
             additional_contributors = [

--- a/autopub/plugins/github.py
+++ b/autopub/plugins/github.py
@@ -61,7 +61,7 @@ class GithubConfig(BaseModel):
 
         ```markdown
         ---
-        release type: patch
+        release-type: patch
         ---
 
         Description of the changes, ideally with some examples, if adding a new feature.

--- a/autopub/plugins/update_changelog.py
+++ b/autopub/plugins/update_changelog.py
@@ -56,12 +56,16 @@ class UpdateChangelogPlugin(AutopubPlugin):
             f.write(f"{VERSION_HEADER * len(new_version_header)}\n\n")
             f.write(release_info.release_notes)
 
-            for line in release_info.additional_release_notes:
-                f.write(f"\n\n{line}")
+            if release_info.additional_release_notes:
+                for line in release_info.additional_release_notes:
+                    f.write(f"\n\n{line}")
 
             # Write old changelog data (skip if empty or only whitespace)
             old_content = "\n".join(old_changelog_data).strip()
             if old_content:
                 f.write("\n\n")
+                # Strip leading empty lines from old changelog data to avoid extra blank lines
+                while old_changelog_data and old_changelog_data[0].strip() == "":
+                    old_changelog_data = old_changelog_data[1:]
                 # Preserve the original formatting including any trailing newlines
                 f.write("\n".join(old_changelog_data))

--- a/autopub/plugins/update_changelog.py
+++ b/autopub/plugins/update_changelog.py
@@ -22,35 +22,46 @@ class UpdateChangelogPlugin(AutopubPlugin):
 
         current_date = date.today().strftime("%Y-%m-%d")
 
-        old_changelog_data = ""
-        header = ""
-
         lines = self.changelog_file.read_text().splitlines()
 
-        for index, line in enumerate(lines):
-            if CHANGELOG_HEADER != line.strip():
-                continue
+        # Look for CHANGELOG header (e.g., "CHANGELOG\n=========")
+        header = []
+        old_changelog_data = []
+        header_found = False
 
-            old_changelog_data = lines[index + 1 :]
-            header = lines[: index + 1]
-            break
+        for index, line in enumerate(lines):
+            if CHANGELOG_HEADER == line.strip():
+                old_changelog_data = lines[index + 1 :]
+                header = lines[: index + 1]
+                header_found = True
+                break
+
+        # If no header found, treat all existing content as old changelog data
+        if not header_found:
+            old_changelog_data = lines
 
         new_version = release_info.version
 
         assert new_version is not None
 
         with self.changelog_file.open("w") as f:
-            f.write("\n".join(header))
-            f.write("\n")
+            # Write header if it exists
+            if header:
+                f.write("\n".join(header))
+                f.write("\n\n")
 
+            # Write new version entry
             new_version_header = f"{new_version} - {current_date}"
-
-            f.write(f"\n{new_version_header}\n")
+            f.write(f"{new_version_header}\n")
             f.write(f"{VERSION_HEADER * len(new_version_header)}\n\n")
             f.write(release_info.release_notes)
 
             for line in release_info.additional_release_notes:
                 f.write(f"\n\n{line}")
 
-            f.write("\n")
-            f.write("\n".join(old_changelog_data))
+            # Write old changelog data (skip if empty or only whitespace)
+            old_content = "\n".join(old_changelog_data).strip()
+            if old_content:
+                f.write("\n\n")
+                # Preserve the original formatting including any trailing newlines
+                f.write("\n".join(old_changelog_data))

--- a/tests/plugins/test_git.py
+++ b/tests/plugins/test_git.py
@@ -1,6 +1,6 @@
 from pytest_mock import MockerFixture
 
-from autopub.plugins.git import GitPlugin
+from autopub.plugins.git import GitConfig, GitPlugin
 from autopub.types import ReleaseInfo
 
 
@@ -29,7 +29,85 @@ def test_post_publish(mocker: MockerFixture) -> None:
     mock_run_command.assert_any_call(["git", "rm", "RELEASE.md"])
     mock_run_command.assert_any_call(["git", "add", "--all", "--", ":!.autopub"])
     mock_run_command.assert_any_call(
-        ["git", "commit", "-m", "🤖 Release v1.0.0\n\n\n\n[skip ci]"]
+        ["git", "commit", "-m", "🤖 Release v1.0.0\n\n\n\n[skip ci]\n"]
     )
     mock_run_command.assert_any_call(["git", "push"])
     mock_run_command.assert_any_call(["git", "push", "origin", "v1.0.0"])
+
+
+def test_post_publish_with_config(mocker: MockerFixture) -> None:
+    """Test git plugin with custom configuration."""
+    git_plugin = GitPlugin()
+    config = {
+        "plugin_config": {
+            "git": {"git-username": "release-bot", "git-email": "bot@example.com"}
+        }
+    }
+    git_plugin.validate_config(config)
+
+    mock_run_command = mocker.patch.object(git_plugin, "run_command")
+
+    release_info = ReleaseInfo(
+        release_notes="test release",
+        release_type="minor",
+        additional_info={},
+        version="v1.1.0",
+        previous_version="v1.0.0",
+    )
+
+    git_plugin.post_publish(release_info)
+
+    mock_run_command.assert_any_call(
+        ["git", "config", "--global", "user.email", "bot@example.com"]
+    )
+    mock_run_command.assert_any_call(
+        ["git", "config", "--global", "user.name", "release-bot"]
+    )
+
+
+def test_post_publish_with_env_vars(mocker: MockerFixture) -> None:
+    """Test git plugin with environment variables (takes precedence over config)."""
+    git_plugin = GitPlugin()
+    config = {
+        "plugin_config": {
+            "git": {"git-username": "config-user", "git-email": "config@example.com"}
+        }
+    }
+    git_plugin.validate_config(config)
+
+    mock_run_command = mocker.patch.object(git_plugin, "run_command")
+    mocker.patch.dict(
+        "os.environ",
+        {"AUTOPUB_GIT_USERNAME": "env-user", "AUTOPUB_GIT_EMAIL": "env@example.com"},
+    )
+
+    release_info = ReleaseInfo(
+        release_notes="test release",
+        release_type="patch",
+        additional_info={},
+        version="v1.0.1",
+        previous_version="v1.0.0",
+    )
+
+    git_plugin.post_publish(release_info)
+
+    # Environment variables should take precedence
+    mock_run_command.assert_any_call(
+        ["git", "config", "--global", "user.email", "env@example.com"]
+    )
+    mock_run_command.assert_any_call(
+        ["git", "config", "--global", "user.name", "env-user"]
+    )
+
+
+def test_git_config_validation() -> None:
+    """Test GitConfig validation with both hyphenated and underscored keys."""
+    # Test with hyphenated keys (expected format)
+    config = GitConfig(**{"git-username": "testuser", "git-email": "test@example.com"})
+    assert config.git_username == "testuser"
+    assert config.git_email == "test@example.com"
+
+    # Test with defaults
+    config = GitConfig()
+    assert config.git_username == "autopub"
+    assert config.git_email == "autopub@autopub"

--- a/tests/plugins/test_git.py
+++ b/tests/plugins/test_git.py
@@ -78,7 +78,7 @@ def test_post_publish_with_env_vars(mocker: MockerFixture) -> None:
     mock_run_command = mocker.patch.object(git_plugin, "run_command")
     mocker.patch.dict(
         "os.environ",
-        {"AUTOPUB_GIT_USERNAME": "env-user", "AUTOPUB_GIT_EMAIL": "env@example.com"},
+        {"GIT_USERNAME": "env-user", "GIT_EMAIL": "env@example.com"},
     )
 
     release_info = ReleaseInfo(

--- a/tests/plugins/test_github.py
+++ b/tests/plugins/test_github.py
@@ -1,0 +1,215 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autopub.plugins.github import GithubPlugin
+from autopub.types import ReleaseInfo
+
+
+@pytest.fixture
+def mock_env(monkeypatch):
+    """Mock required environment variables."""
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+
+
+@pytest.fixture
+def github_plugin(mock_env):
+    """Create a GithubPlugin instance with mocked dependencies."""
+    with patch("autopub.plugins.github.Github"):
+        plugin = GithubPlugin()
+        # Initialize config with default values
+        plugin.validate_config({})
+        return plugin
+
+
+def test_on_release_notes_valid_with_markdown_links(github_plugin):
+    """Test that markdown links are added to CHANGELOG for contributors and PR."""
+    # Mock pull request
+    mock_pr = MagicMock()
+    mock_pr.number = 123
+    mock_pr.html_url = "https://github.com/owner/repo/pull/123"
+    mock_pr.user.login = "contributor"
+    mock_pr.get_commits.return_value = []
+    mock_pr.get_issue_comments.return_value = []
+
+    github_plugin.pull_request = mock_pr
+
+    release_info = ReleaseInfo(
+        release_type="minor",
+        release_notes="Test release",
+        version="1.0.0",
+        previous_version="0.9.0",
+    )
+
+    github_plugin.on_release_notes_valid(release_info)
+
+    # Verify markdown links were added to additional_release_notes
+    assert len(release_info.additional_release_notes) == 1
+    assert (
+        "[@contributor](https://github.com/contributor)"
+        in release_info.additional_release_notes[0]
+    )
+    assert (
+        "[#123](https://github.com/owner/repo/pull/123)"
+        in release_info.additional_release_notes[0]
+    )
+
+
+def test_on_release_notes_valid_with_additional_contributors(github_plugin):
+    """Test that additional contributors are properly formatted with markdown links."""
+    # Mock pull request with additional contributors
+    mock_pr = MagicMock()
+    mock_pr.number = 456
+    mock_pr.html_url = "https://github.com/owner/repo/pull/456"
+    mock_pr.user.login = "main-author"
+
+    # Mock commit with different author
+    mock_commit = MagicMock()
+    mock_commit.author.login = "co-author"
+    mock_commit.commit.message = "Some commit"
+    mock_pr.get_commits.return_value = [mock_commit]
+    mock_pr.get_issue_comments.return_value = []
+
+    github_plugin.pull_request = mock_pr
+
+    release_info = ReleaseInfo(
+        release_type="patch",
+        release_notes="Bug fix",
+        version="1.0.1",
+        previous_version="1.0.0",
+    )
+
+    github_plugin.on_release_notes_valid(release_info)
+
+    # Verify both contributor line and additional contributors line
+    assert len(release_info.additional_release_notes) == 2
+    assert (
+        "[@main-author](https://github.com/main-author)"
+        in release_info.additional_release_notes[0]
+    )
+    assert "Additional contributors:" in release_info.additional_release_notes[1]
+    assert (
+        "[@co-author](https://github.com/co-author)"
+        in release_info.additional_release_notes[1]
+    )
+
+
+def test_on_release_notes_valid_with_co_authored_by(github_plugin):
+    """Test that Co-authored-by trailers are parsed correctly."""
+    mock_pr = MagicMock()
+    mock_pr.number = 789
+    mock_pr.html_url = "https://github.com/owner/repo/pull/789"
+    mock_pr.user.login = "author"
+
+    # Mock commit with Co-authored-by trailer
+    mock_commit = MagicMock()
+    mock_commit.author.login = "author"
+    mock_commit.commit.message = (
+        "Fix bug\n\nCo-authored-by: helper <helper@example.com>"
+    )
+    mock_pr.get_commits.return_value = [mock_commit]
+    mock_pr.get_issue_comments.return_value = []
+
+    github_plugin.pull_request = mock_pr
+
+    release_info = ReleaseInfo(
+        release_type="patch",
+        release_notes="Bug fix with co-author",
+        version="1.0.2",
+        previous_version="1.0.1",
+    )
+
+    github_plugin.on_release_notes_valid(release_info)
+
+    # Verify co-author was picked up
+    assert len(release_info.additional_release_notes) == 2
+    assert (
+        "[@helper](https://github.com/helper)"
+        in release_info.additional_release_notes[1]
+    )
+
+
+def test_on_release_notes_valid_no_pr_context(github_plugin):
+    """Test that no modifications are made when there's no PR context."""
+    github_plugin.pull_request = None
+
+    release_info = ReleaseInfo(
+        release_type="minor",
+        release_notes="Direct push release",
+        version="2.0.0",
+        previous_version="1.0.0",
+    )
+
+    github_plugin.on_release_notes_valid(release_info)
+
+    # Verify no additional_release_notes were added
+    assert len(release_info.additional_release_notes) == 0
+
+
+def test_get_release_message_with_pr_context(github_plugin):
+    """Test that _get_release_message includes contributor info with @ mentions (not markdown)."""
+    mock_pr = MagicMock()
+    mock_pr.number = 100
+    mock_pr.html_url = "https://github.com/owner/repo/pull/100"
+    mock_pr.user.login = "testuser"
+    mock_pr.get_commits.return_value = []
+
+    github_plugin.pull_request = mock_pr
+
+    release_info = ReleaseInfo(
+        release_type="major",
+        release_notes="Major release",
+        version="2.0.0",
+        previous_version="1.0.0",
+    )
+
+    message = github_plugin._get_release_message(
+        release_info, include_release_info=True
+    )
+
+    # For GitHub releases, use @ mentions, not markdown links
+    assert "Major release" in message
+    assert "@testuser" in message
+    assert "https://github.com/owner/repo/pull/100" in message
+
+
+def test_get_release_message_without_pr_context(github_plugin):
+    """Test that _get_release_message returns just release notes when no PR context."""
+    github_plugin.pull_request = None
+
+    release_info = ReleaseInfo(
+        release_type="minor",
+        release_notes="No PR release",
+        version="1.5.0",
+        previous_version="1.4.0",
+    )
+
+    message = github_plugin._get_release_message(
+        release_info, include_release_info=True
+    )
+
+    # Should return just the release notes
+    assert message == "No PR release"
+
+
+def test_get_release_message_without_include_release_info(github_plugin):
+    """Test that _get_release_message returns just notes when include_release_info=False."""
+    mock_pr = MagicMock()
+    mock_pr.number = 200
+    github_plugin.pull_request = mock_pr
+
+    release_info = ReleaseInfo(
+        release_type="patch",
+        release_notes="Simple fix",
+        version="1.0.1",
+        previous_version="1.0.0",
+    )
+
+    message = github_plugin._get_release_message(
+        release_info, include_release_info=False
+    )
+
+    # Should return just the release notes, no contributor info
+    assert message == "Simple fix"
+    assert "@" not in message

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "autopub"
-version = "1.0.0a50"
+version = "1.0.0a53"
 source = { editable = "." }
 dependencies = [
     { name = "dunamai" },


### PR DESCRIPTION
## Summary

This PR adds three key improvements to autopub:

1. **Configurable Git Identity** - Allow git username/email to be set via environment variables or pyproject.toml for proper commit attribution in CI/CD workflows
2. **Markdown Links in CHANGELOGs** - Format contributor usernames and PR references as clickable markdown links in CHANGELOG.md
3. **Improved Changelog Formatting** - Fix blank line handling to ensure clean, consistent changelog entries

## Changes

### Git Plugin
- Add `GitConfig` model with `git-username` and `git-email` fields
- Support `GIT_USERNAME` and `GIT_EMAIL` environment variables
- Environment variables take precedence over pyproject.toml config
- Default values preserved for backward compatibility (`autopub@autopub`)
- **Use case**: Enables proper commit attribution when autopub runs in GitHub Actions (e.g., `botberry[bot] <50026275+botberry[bot]@users.noreply.github.com>`)

### GitHub Plugin
- Format contributors as markdown links in CHANGELOG: `[@username](https://github.com/username)`
- Format PR references as markdown links: `[#123](https://github.com/owner/repo/pull/123)`
- GitHub releases continue using @ mentions for proper notifications
- Fix spacing in release messages (add blank line before contributor info)

### Update Changelog Plugin
- Fix extra blank lines when no additional release notes
- Strip leading empty lines from old changelog data to prevent triple newlines
- Improve handling of changelogs without standard header