### PR TITLE
Add --index support to uv plugin for custom repositories

### DIFF
--- a/autopub/plugins/uv.py
+++ b/autopub/plugins/uv.py
@@ -25,7 +25,8 @@ class UvPlugin(BumpVersionPlugin, AutopubPackageManagerPlugin):
         additional_args: list[str] = []
 
         if repository:
-            raise ValueError("Not yet implemented")
+            additional_args.append("--index")
+            additional_args.append(repository)
 
         if publish_url := kwargs.get("publish_url"):
             additional_args.append("--publish-url")

--- a/tests/plugins/test_uv.py
+++ b/tests/plugins/test_uv.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import tomlkit
 from pytest_httpserver import HTTPServer
 
 from autopub.plugins.uv import UvPlugin
@@ -50,3 +51,30 @@ def test_bumps_version_and_updates_lock(example_project_uv: Path):
     # Check that uv.lock exists (it should be regenerated)
     # Note: uv.lock may not exist in the test fixture, but the command should run
     # without error. In a real project with dependencies, it would be created/updated.
+
+
+def test_runs_publish_with_repository(example_project_uv: Path, httpserver: HTTPServer):
+    """Test that publish works with a named repository (--index)."""
+    httpserver.expect_request("/legacy/").respond_with_data(
+        "OK", status=200, content_type="text/plain"
+    )
+
+    url = httpserver.url_for("/legacy/")
+
+    # Configure an explicit index in pyproject.toml with publish-url
+    # explicit = true prevents the index from being used for dependency resolution
+    pyproject_path = example_project_uv / "pyproject.toml"
+    pyproject = tomlkit.loads(pyproject_path.read_text())
+    pyproject.setdefault("tool", {}).setdefault("uv", {})["index"] = [
+        {
+            "name": "example",
+            "url": "https://example.com/simple/",
+            "publish-url": url,
+            "explicit": True,
+        }
+    ]
+    pyproject_path.write_text(tomlkit.dumps(pyproject))
+
+    uv = UvPlugin()
+    uv.build()
+    uv.publish(repository="example", username="example", password="example")


### PR DESCRIPTION
## Summary

- Enable the uv plugin to publish to named indexes configured in `pyproject.toml` via `[[tool.uv.index]]`
- Maps the autopub `repository` parameter to uv's `--index` CLI option
- Adds integration test that configures an explicit index with `publish-url`

## Details

The index must be configured in `pyproject.toml` with a `publish-url` setting:

```toml
[[tool.uv.index]]
name = "private"
url = "https://example.com/simple/"
publish-url = "https://example.com/legacy/"
explicit = true  # optional, prevents use for dependency resolution
```

Then publish with:
```bash
autopub publish --repository private
```

This follows the same pattern as the Poetry and PDM plugins which also support the `repository` parameter for named repositories.