### PR TITLE
Don't fail releases when the GitHub plugin can't post a PR comment

### DIFF
--- a/autopub/exceptions.py
+++ b/autopub/exceptions.py
@@ -8,6 +8,14 @@ class AutopubException(Exception):
         super().__init__(message or self.message)
 
 
+class AutopubWarning(UserWarning):
+    """Base class for non-fatal autopub warnings.
+
+    Used for problems that should be surfaced but must not abort a release,
+    such as failing to post a PR comment.
+    """
+
+
 class ReleaseFileNotFound(AutopubException):
     message = "Release file not found"
 

--- a/autopub/plugins/github.py
+++ b/autopub/plugins/github.py
@@ -2,15 +2,16 @@ import json
 import os
 import pathlib
 import textwrap
+import warnings
 from functools import cached_property
 from typing import Optional, TypedDict
 
-from github import Github
+from github import Github, GithubException
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 from pydantic import BaseModel
 
-from autopub.exceptions import AutopubException
+from autopub.exceptions import AutopubException, AutopubWarning
 from autopub.plugins import AutopubPlugin
 from autopub.types import ReleaseInfo
 
@@ -149,18 +150,38 @@ class GithubPlugin(AutopubPlugin):
     def _update_or_create_comment(
         self, text: str, marker: str = "<!-- autopub-comment -->"
     ) -> None:
-        """Update or create a comment on the current PR with the given text."""
+        """Update or create a comment on the current PR with the given text.
+
+        Posting a comment is a best-effort side effect, not part of the release
+        itself. If there is no PR to comment on, or the GitHub API rejects the
+        request -- most commonly because the workflow token is missing
+        ``issues: write`` / ``pull-requests: write`` permissions -- we skip it
+        (warning on API errors) rather than failing the whole release.
+        """
+        if self.pull_request is None:
+            return
+
         comment_body = f"{marker}\n{text}"
 
-        # Search for existing comment
-        for comment in self.pull_request.get_issue_comments():
-            if marker in comment.body:
-                # Update existing comment
-                comment.edit(comment_body)
-                return
+        try:
+            # Update an existing comment if we've commented before...
+            for comment in self.pull_request.get_issue_comments():
+                if marker in comment.body:
+                    comment.edit(comment_body)
+                    return
 
-        # Create new comment if none exists
-        self.pull_request.create_issue_comment(comment_body)
+            # ...otherwise create a new one.
+            self.pull_request.create_issue_comment(comment_body)
+        except GithubException as exc:
+            warnings.warn(
+                f"Could not post a comment on pull request "
+                f"#{self.pull_request.number}: {exc}. This is usually caused by "
+                "the workflow token missing 'issues: write' / "
+                "'pull-requests: write' permissions; the release will continue "
+                "without it.",
+                AutopubWarning,
+                stacklevel=2,
+            )
 
     def _get_sponsors(self) -> Sponsors:
         query_organisation = """

--- a/tests/plugins/test_github.py
+++ b/tests/plugins/test_github.py
@@ -1,7 +1,9 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from github import GithubException
 
+from autopub.exceptions import AutopubWarning
 from autopub.plugins.github import GithubPlugin
 from autopub.types import ReleaseInfo
 
@@ -213,3 +215,75 @@ def test_get_release_message_without_include_release_info(github_plugin):
     # Should return just the release notes, no contributor info
     assert message == "Simple fix"
     assert "@" not in message
+
+
+def test_update_or_create_comment_skips_without_pr(github_plugin):
+    """Without a PR there's nothing to comment on, so it's a no-op."""
+    github_plugin.pull_request = None
+
+    # Should not raise.
+    github_plugin._update_or_create_comment("hello")
+
+
+def test_update_or_create_comment_creates_when_none_exists(github_plugin):
+    """A new comment is created when no matching comment exists yet."""
+    mock_pr = MagicMock()
+    mock_pr.get_issue_comments.return_value = []
+    github_plugin.pull_request = mock_pr
+
+    github_plugin._update_or_create_comment("hello", marker="<!-- m -->")
+
+    mock_pr.create_issue_comment.assert_called_once_with("<!-- m -->\nhello")
+
+
+def test_update_or_create_comment_edits_existing(github_plugin):
+    """An existing comment with the same marker is edited, not duplicated."""
+    existing = MagicMock()
+    existing.body = "<!-- m -->\nold"
+    mock_pr = MagicMock()
+    mock_pr.get_issue_comments.return_value = [existing]
+    github_plugin.pull_request = mock_pr
+
+    github_plugin._update_or_create_comment("new", marker="<!-- m -->")
+
+    existing.edit.assert_called_once_with("<!-- m -->\nnew")
+    mock_pr.create_issue_comment.assert_not_called()
+
+
+def test_update_or_create_comment_warns_on_api_error(github_plugin):
+    """A GitHub API error (e.g. missing permissions) warns instead of raising."""
+    mock_pr = MagicMock()
+    mock_pr.number = 42
+    mock_pr.get_issue_comments.return_value = []
+    mock_pr.create_issue_comment.side_effect = GithubException(
+        403, {"message": "Resource not accessible by integration"}, None
+    )
+    github_plugin.pull_request = mock_pr
+
+    with pytest.warns(AutopubWarning, match="issues: write"):
+        github_plugin._update_or_create_comment("hello")
+
+
+def test_post_publish_creates_release_even_if_comment_fails(github_plugin):
+    """A failed publish comment must not stop the GitHub release from being created."""
+    mock_pr = MagicMock()
+    mock_pr.number = 7
+    mock_pr.get_issue_comments.return_value = []
+    mock_pr.create_issue_comment.side_effect = GithubException(
+        403, {"message": "Resource not accessible by integration"}, None
+    )
+    github_plugin.pull_request = mock_pr
+    github_plugin.repository = MagicMock()
+    github_plugin._create_release = MagicMock()
+
+    release_info = ReleaseInfo(
+        release_type="major",
+        release_notes="Release",
+        version="1.0.0",
+        previous_version="0.1.0",
+    )
+
+    with pytest.warns(AutopubWarning, match="Could not post a comment"):
+        github_plugin.post_publish(release_info)
+
+    github_plugin._create_release.assert_called_once()

--- a/tests/plugins/test_poetry.py
+++ b/tests/plugins/test_poetry.py
@@ -15,13 +15,13 @@ def test_runs_build(example_project: Path):
 
 
 def test_runs_publish(example_project: Path, httpserver: HTTPServer):
-    httpserver.expect_request("/legacy").respond_with_data(
+    httpserver.expect_request("/legacy/").respond_with_data(
         "OK", status=200, content_type="text/plain"
     )
 
-    url = httpserver.url_for("/legacy")
+    url = httpserver.url_for("/legacy/")
 
-    subprocess.run(["poetry", "config", "repositories.example", url])
+    subprocess.run(["poetry", "config", "repositories.example", url], check=True)
 
     poetry = PoetryPlugin()
     poetry.build()


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- **#62** (`2026-06-18-don-t-fail-releases-when-the-github-plugin-can-t-p`) <-- this PR
<!-- shortcake:end -->