### PR TITLE
Fix GitHub contributor detection for unlinked commit authors

### DIFF
--- a/autopub/plugins/github.py
+++ b/autopub/plugins/github.py
@@ -328,8 +328,12 @@ class GithubPlugin(AutopubPlugin):
         )
 
         for commit in pr.get_commits():
-            if commit.author.login != pr_author:
-                pr_contributors["additional_contributors"].add(commit.author.login)
+            commit_author_login = None
+            if commit.author is not None:
+                commit_author_login = commit.author.login
+
+            if commit_author_login and commit_author_login != pr_author:
+                pr_contributors["additional_contributors"].add(commit_author_login)
 
             for commit_message in commit.commit.message.split("\n"):
                 if commit_message.startswith("Co-authored-by:"):
@@ -449,10 +453,15 @@ class GithubPlugin(AutopubPlugin):
     def pre_publish(self, release_info: ReleaseInfo) -> None:
         # Set remote URL with token for authenticated pushes
         if self.repository_name:
-            self.run_command([
-                "git", "remote", "set-url", "origin",
-                f"https://{self.github_token}@github.com/{self.repository_name}"
-            ])
+            self.run_command(
+                [
+                    "git",
+                    "remote",
+                    "set-url",
+                    "origin",
+                    f"https://{self.github_token}@github.com/{self.repository_name}",
+                ]
+            )
 
     def post_publish(self, release_info: ReleaseInfo) -> None:
         if self.pull_request is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 requires-python = ">=3.9.0,<4.0"
-version = "1.0.0-alpha.58"
+version = "1.0.0-alpha.59"
 name = "autopub"
 description = "Automatic package release upon pull request merge"
 authors = [

--- a/tests/plugins/test_github.py
+++ b/tests/plugins/test_github.py
@@ -97,6 +97,37 @@ def test_on_release_notes_valid_with_additional_contributors(github_plugin):
     )
 
 
+def test_on_release_notes_valid_with_unlinked_commit_author(github_plugin):
+    """Test that commits without linked GitHub authors do not crash."""
+    mock_pr = MagicMock()
+    mock_pr.number = 457
+    mock_pr.html_url = "https://github.com/owner/repo/pull/457"
+    mock_pr.user.login = "main-author"
+
+    mock_commit = MagicMock()
+    mock_commit.author = None
+    mock_commit.commit.message = "Some commit"
+    mock_pr.get_commits.return_value = [mock_commit]
+    mock_pr.get_issue_comments.return_value = []
+
+    github_plugin.pull_request = mock_pr
+
+    release_info = ReleaseInfo(
+        release_type="patch",
+        release_notes="Bug fix",
+        version="1.0.1",
+        previous_version="1.0.0",
+    )
+
+    github_plugin.on_release_notes_valid(release_info)
+
+    assert len(release_info.additional_release_notes) == 1
+    assert (
+        "[@main-author](https://github.com/main-author)"
+        in release_info.additional_release_notes[0]
+    )
+
+
 def test_on_release_notes_valid_with_co_authored_by(github_plugin):
     """Test that Co-authored-by trailers are parsed correctly."""
     mock_pr = MagicMock()


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- **#63** (`2026-07-09-fix-github-contributor-detection-for-unlinked-comm`) <-- this PR
<!-- shortcake:end -->