### PR TITLE
Support workflow_run events in GithubPlugin

### DIFF
--- a/autopub/plugins/github.py
+++ b/autopub/plugins/github.py
@@ -129,12 +129,22 @@ class GithubPlugin(AutopubPlugin):
         if self._event_data.get("pull_request"):
             return self._event_data["pull_request"]["number"]
 
-        # For push events (including PR merges), prefer head_commit over commits[0]
-        # as commits[0] may be a branch commit, not the merge commit
+        # Resolve the commit SHA to find the associated PR. Push events
+        # (including PR merges) carry it in head_commit/commits[0]; workflow_run
+        # events carry it in workflow_run.head_sha; otherwise fall back to
+        # $GITHUB_SHA. This lets releases run on workflow_run (e.g. to collect
+        # multi-platform wheels built in a separate CI run) instead of only push.
         if self._event_data.get("head_commit"):
             sha = self._event_data["head_commit"]["id"]
-        else:
+        elif self._event_data.get("commits"):
             sha = self._event_data["commits"][0]["id"]
+        elif self._event_data.get("workflow_run"):
+            sha = self._event_data["workflow_run"].get("head_sha")
+        else:
+            sha = os.environ.get("GITHUB_SHA")
+
+        if not sha:
+            return None
 
         commit = self.repository.get_commit(sha)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 requires-python = ">=3.9.0,<4.0"
-version = "1.0.0-alpha.59"
+version = "1.0.0-alpha.60"
 name = "autopub"
 description = "Automatic package release upon pull request merge"
 authors = [

--- a/tests/plugins/test_github.py
+++ b/tests/plugins/test_github.py
@@ -318,3 +318,53 @@ def test_post_publish_creates_release_even_if_comment_fails(github_plugin):
         github_plugin.post_publish(release_info)
 
     github_plugin._create_release.assert_called_once()
+
+
+def _write_event(monkeypatch, tmp_path, payload):
+    import json
+
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps(payload))
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+
+
+def test_get_pr_number_from_workflow_run_event(github_plugin, monkeypatch, tmp_path):
+    """A workflow_run payload has no top-level commits/head_commit; the SHA
+    comes from workflow_run.head_sha and must not raise KeyError."""
+    _write_event(monkeypatch, tmp_path, {"workflow_run": {"head_sha": "abc123"}})
+
+    mock_pr = MagicMock()
+    mock_pr.number = 42
+    mock_commit = MagicMock()
+    mock_commit.get_pulls.return_value = [mock_pr]
+    github_plugin.repository = MagicMock()
+    github_plugin.repository.get_commit.return_value = mock_commit
+
+    assert github_plugin._get_pr_number() == 42
+    github_plugin.repository.get_commit.assert_called_once_with("abc123")
+
+
+def test_get_pr_number_falls_back_to_github_sha(github_plugin, monkeypatch, tmp_path):
+    """When the payload carries no commit info, fall back to $GITHUB_SHA."""
+    _write_event(monkeypatch, tmp_path, {"action": "completed"})
+    monkeypatch.setenv("GITHUB_SHA", "def456")
+
+    mock_pr = MagicMock()
+    mock_pr.number = 7
+    mock_commit = MagicMock()
+    mock_commit.get_pulls.return_value = [mock_pr]
+    github_plugin.repository = MagicMock()
+    github_plugin.repository.get_commit.return_value = mock_commit
+
+    assert github_plugin._get_pr_number() == 7
+    github_plugin.repository.get_commit.assert_called_once_with("def456")
+
+
+def test_get_pr_number_returns_none_without_commit_info(github_plugin, monkeypatch, tmp_path):
+    """No commit info anywhere -> return None instead of raising."""
+    _write_event(monkeypatch, tmp_path, {"action": "completed"})
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    github_plugin.repository = MagicMock()
+
+    assert github_plugin._get_pr_number() is None
+    github_plugin.repository.get_commit.assert_not_called()


### PR DESCRIPTION
## Problem

`GithubPlugin._get_pr_number()` resolves the commit SHA like this:

```python
if self._event_data.get("head_commit"):
    sha = self._event_data["head_commit"]["id"]
else:
    sha = self._event_data["commits"][0]["id"]
```

This assumes a **push**-event payload. On a **`workflow_run`** event the payload has neither `head_commit` nor top-level `commits` (the SHA lives at `workflow_run.head_sha`), so it raises `KeyError: 'commits'`.

`post_publish` evaluates `self.pull_request` (→ `_get_pr_number`) on its first line, so the exception aborts the publish **after** PyPI upload, the git push, and the tag have all succeeded — the GitHub release is never created.

## Why it matters

Pure-Python projects release on `push` (payload has `commits`), so this never fires. But compiled-extension projects (maturin/PyO3, pybind, cython) can't build their wheels inline — they need a multi-platform matrix (manylinux, musllinux, windows-arm, s390x, …) built in a separate CI run, then publish from a **`workflow_run`** job that downloads the artifacts. That's the path that hits this. Found releasing a Rust/PyO3 project.

## Fix

Resolve the SHA from `head_commit` → `commits[0]` → `workflow_run.head_sha` → `$GITHUB_SHA`, and return `None` (no PR association) when none is available. Push releases are unchanged; `workflow_run` and other event shapes now degrade gracefully instead of raising.

Added 3 tests (workflow_run resolution, `$GITHUB_SHA` fallback, graceful `None`). Bumped to `1.0.0-alpha.60`.

> Note: the 4 pre-existing `test_pdm`/`test_poetry` failures locally are just missing `pdm`/`poetry` binaries in my env, unrelated to this change.