### PR TITLE
Only post release validation comments on PR checks

### DIFF
--- a/autopub/plugins/github.py
+++ b/autopub/plugins/github.py
@@ -193,6 +193,19 @@ class GithubPlugin(AutopubPlugin):
                 stacklevel=2,
             )
 
+    def _should_comment_on_release_check(self) -> bool:
+        """Return whether release validation feedback belongs on a PR.
+
+        Pull request workflows use ``autopub check`` to give contributors
+        feedback. Release workflows also run the command as a gate after merge,
+        but should report failures through their job status instead of commenting
+        on the associated PR.
+        """
+        return os.environ.get("GITHUB_EVENT_NAME") in {
+            "pull_request",
+            "pull_request_target",
+        }
+
     def _get_sponsors(self) -> Sponsors:
         query_organisation = """
             query GetSponsors($organization: String!) {
@@ -378,7 +391,7 @@ class GithubPlugin(AutopubPlugin):
                 f"Additional contributors: {', '.join(additional_contributors)}"
             )
 
-        if self.pull_request.state != "open":
+        if not self._should_comment_on_release_check():
             return
 
         changelog = self._get_release_message(release_info)
@@ -390,7 +403,7 @@ class GithubPlugin(AutopubPlugin):
         self._update_or_create_comment(message)
 
     def on_release_file_not_found(self) -> None:
-        if self.pull_request is None or self.pull_request.state != "open":
+        if not self._should_comment_on_release_check():
             return
 
         message = self.config.comment_template_missing_release
@@ -398,7 +411,7 @@ class GithubPlugin(AutopubPlugin):
         self._update_or_create_comment(message)
 
     def on_release_notes_invalid(self, exception: AutopubException) -> None:
-        if self.pull_request is None or self.pull_request.state != "open":
+        if not self._should_comment_on_release_check():
             return
 
         message = self.config.comment_template_error.format(error=str(exception))

--- a/autopub/plugins/github.py
+++ b/autopub/plugins/github.py
@@ -378,6 +378,9 @@ class GithubPlugin(AutopubPlugin):
                 f"Additional contributors: {', '.join(additional_contributors)}"
             )
 
+        if self.pull_request.state != "open":
+            return
+
         changelog = self._get_release_message(release_info)
 
         message = self.config.comment_template_success.format(
@@ -387,11 +390,17 @@ class GithubPlugin(AutopubPlugin):
         self._update_or_create_comment(message)
 
     def on_release_file_not_found(self) -> None:
+        if self.pull_request is None or self.pull_request.state != "open":
+            return
+
         message = self.config.comment_template_missing_release
 
         self._update_or_create_comment(message)
 
     def on_release_notes_invalid(self, exception: AutopubException) -> None:
+        if self.pull_request is None or self.pull_request.state != "open":
+            return
+
         message = self.config.comment_template_error.format(error=str(exception))
 
         self._update_or_create_comment(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 requires-python = ">=3.9.0,<4.0"
-version = "1.0.0-alpha.60"
+version = "1.0.0-alpha.61"
 name = "autopub"
 description = "Automatic package release upon pull request merge"
 authors = [

--- a/tests/plugins/test_github.py
+++ b/tests/plugins/test_github.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from github import GithubException
 
-from autopub.exceptions import AutopubWarning
+from autopub.exceptions import AutopubException, AutopubWarning
 from autopub.plugins.github import GithubPlugin
 from autopub.types import ReleaseInfo
 
@@ -281,6 +281,27 @@ def test_update_or_create_comment_edits_existing(github_plugin):
     mock_pr.create_issue_comment.assert_not_called()
 
 
+def test_release_validation_hooks_skip_comments_for_closed_pr(github_plugin):
+    """Release validation does not call the comment helper after a PR closes."""
+    mock_pr = MagicMock()
+    mock_pr.state = "closed"
+    github_plugin.pull_request = mock_pr
+    github_plugin._update_or_create_comment = MagicMock()
+
+    release_info = ReleaseInfo(
+        release_type="patch",
+        release_notes="Bug fix",
+        version="1.0.1",
+        previous_version="1.0.0",
+    )
+
+    github_plugin.on_release_notes_valid(release_info)
+    github_plugin.on_release_file_not_found()
+    github_plugin.on_release_notes_invalid(AutopubException("invalid release"))
+
+    github_plugin._update_or_create_comment.assert_not_called()
+
+
 def test_update_or_create_comment_warns_on_api_error(github_plugin):
     """A GitHub API error (e.g. missing permissions) warns instead of raising."""
     mock_pr = MagicMock()
@@ -299,6 +320,7 @@ def test_post_publish_creates_release_even_if_comment_fails(github_plugin):
     """A failed publish comment must not stop the GitHub release from being created."""
     mock_pr = MagicMock()
     mock_pr.number = 7
+    mock_pr.state = "closed"
     mock_pr.get_issue_comments.return_value = []
     mock_pr.create_issue_comment.side_effect = GithubException(
         403, {"message": "Resource not accessible by integration"}, None
@@ -360,7 +382,9 @@ def test_get_pr_number_falls_back_to_github_sha(github_plugin, monkeypatch, tmp_
     github_plugin.repository.get_commit.assert_called_once_with("def456")
 
 
-def test_get_pr_number_returns_none_without_commit_info(github_plugin, monkeypatch, tmp_path):
+def test_get_pr_number_returns_none_without_commit_info(
+    github_plugin, monkeypatch, tmp_path
+):
     """No commit info anywhere -> return None instead of raising."""
     _write_event(monkeypatch, tmp_path, {"action": "completed"})
     monkeypatch.delenv("GITHUB_SHA", raising=False)

--- a/tests/plugins/test_github.py
+++ b/tests/plugins/test_github.py
@@ -281,10 +281,26 @@ def test_update_or_create_comment_edits_existing(github_plugin):
     mock_pr.create_issue_comment.assert_not_called()
 
 
-def test_release_validation_hooks_skip_comments_for_closed_pr(github_plugin):
-    """Release validation does not call the comment helper after a PR closes."""
+@pytest.mark.parametrize(
+    ("event_name", "expected_comment_count"),
+    [
+        ("push", 0),
+        ("workflow_run", 0),
+        ("pull_request", 3),
+        ("pull_request_target", 3),
+    ],
+)
+def test_release_validation_comments_follow_event_context(
+    github_plugin, monkeypatch, event_name, expected_comment_count
+):
+    """Only pull request checks leave release validation feedback."""
+    monkeypatch.setenv("GITHUB_EVENT_NAME", event_name)
+
     mock_pr = MagicMock()
-    mock_pr.state = "closed"
+    mock_pr.number = 123
+    mock_pr.html_url = "https://github.com/owner/repo/pull/123"
+    mock_pr.user.login = "contributor"
+    mock_pr.get_commits.return_value = []
     github_plugin.pull_request = mock_pr
     github_plugin._update_or_create_comment = MagicMock()
 
@@ -299,7 +315,8 @@ def test_release_validation_hooks_skip_comments_for_closed_pr(github_plugin):
     github_plugin.on_release_file_not_found()
     github_plugin.on_release_notes_invalid(AutopubException("invalid release"))
 
-    github_plugin._update_or_create_comment.assert_not_called()
+    assert github_plugin._update_or_create_comment.call_count == expected_comment_count
+    assert len(release_info.additional_release_notes) == 1
 
 
 def test_update_or_create_comment_warns_on_api_error(github_plugin):
@@ -316,11 +333,12 @@ def test_update_or_create_comment_warns_on_api_error(github_plugin):
         github_plugin._update_or_create_comment("hello")
 
 
-def test_post_publish_creates_release_even_if_comment_fails(github_plugin):
+def test_post_publish_creates_release_even_if_comment_fails(github_plugin, monkeypatch):
     """A failed publish comment must not stop the GitHub release from being created."""
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+
     mock_pr = MagicMock()
     mock_pr.number = 7
-    mock_pr.state = "closed"
     mock_pr.get_issue_comments.return_value = []
     mock_pr.create_issue_comment.side_effect = GithubException(
         403, {"message": "Resource not accessible by integration"}, None


### PR DESCRIPTION
## Summary

- post release validation feedback only from `pull_request` and `pull_request_target` checks
- keep `push` and `workflow_run` release gates silent while preserving their job status
- preserve contributor attribution and the intentional post-publish notification
- bump AutoPub to `1.0.0-alpha.61`

## Root cause

The GitHub plugin uses the same `autopub check` hooks in two different contexts: pull request validation and the release gate that runs after merge. A release workflow can resolve its commit back to the merged pull request, so the validation hooks posted a missing-release comment even though that workflow only needed to decide whether to publish.

The validation hooks now use `GITHUB_EVENT_NAME` to distinguish those contexts. Pull request workflows continue to leave actionable feedback. Release workflows report missing or invalid release notes through their job result and do not call the PR comment helper. Contributor attribution still runs during a valid release check, and `post_publish` remains independent so it can comment with the published version after release.

## Validation

- `uv run --frozen --with pdm --with poetry pytest -q` — 80 passed
- `uv run --frozen ruff check autopub/plugins/github.py tests/plugins/test_github.py`
- `uv run --frozen ruff format --check autopub/plugins/github.py tests/plugins/test_github.py`
- `git diff --check`
