### PR TITLE
Resolve co-author GitHub identities

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+---
+release type: patch
+---
+
+Resolve co-authored commit contributors using their GitHub identities instead of
+interpreting display names as usernames.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,0 @@
----
-release type: patch
----
-
-Resolve co-authored commit contributors using their GitHub identities instead of
-interpreting display names as usernames.

--- a/autopub/plugins/github.py
+++ b/autopub/plugins/github.py
@@ -341,6 +341,31 @@ class GithubPlugin(AutopubPlugin):
 
         return response["data"]["createDiscussion"]["discussion"]["url"]
 
+    def _get_commit_author_logins(self, commit_node_id: str) -> set[str]:
+        query = """
+            query GetCommitAuthors($commitId: ID!) {
+                node(id: $commitId) {
+                    ... on Commit {
+                        authors(first: 100) {
+                            nodes {
+                                user {
+                                    login
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        _, response = self._github.requester.graphql_query(
+            query, {"commitId": commit_node_id}
+        )
+
+        authors = response["data"]["node"]["authors"]["nodes"]
+
+        return {author["user"]["login"] for author in authors if author["user"]}
+
     def _get_pr_contributors(self) -> PRContributors:
         pr: PullRequest = self.pull_request
 
@@ -360,11 +385,13 @@ class GithubPlugin(AutopubPlugin):
 
             for commit_message in commit.commit.message.split("\n"):
                 if commit_message.startswith("Co-authored-by:"):
-                    author = commit_message.split(":")[1].strip()
-                    author_login = author.split(" ")[0]
-
-                    if author_login != pr_author:
-                        pr_contributors["additional_contributors"].add(author_login)
+                    coauthors = self._get_commit_author_logins(
+                        commit.raw_data["node_id"]
+                    )
+                    pr_contributors["additional_contributors"].update(
+                        coauthors - {pr_author}
+                    )
+                    break
 
         return pr_contributors
 

--- a/tests/plugins/test_github.py
+++ b/tests/plugins/test_github.py
@@ -139,12 +139,29 @@ def test_on_release_notes_valid_with_co_authored_by(github_plugin):
     mock_commit = MagicMock()
     mock_commit.author.login = "author"
     mock_commit.commit.message = (
-        "Fix bug\n\nCo-authored-by: helper <helper@example.com>"
+        "Fix bug\n\nCo-authored-by: Helpful Person <helper@example.com>"
     )
+    mock_commit.raw_data = {"node_id": "commit-id"}
     mock_pr.get_commits.return_value = [mock_commit]
     mock_pr.get_issue_comments.return_value = []
 
     github_plugin.pull_request = mock_pr
+    github_plugin.__dict__["_github"] = MagicMock()
+    github_plugin._github.requester.graphql_query.return_value = (
+        None,
+        {
+            "data": {
+                "node": {
+                    "authors": {
+                        "nodes": [
+                            {"user": {"login": "author"}},
+                            {"user": {"login": "helper"}},
+                        ]
+                    }
+                }
+            }
+        },
+    )
 
     release_info = ReleaseInfo(
         release_type="patch",
@@ -161,6 +178,44 @@ def test_on_release_notes_valid_with_co_authored_by(github_plugin):
         "[@helper](https://github.com/helper)"
         in release_info.additional_release_notes[1]
     )
+
+
+def test_get_pr_contributors_does_not_treat_coauthor_name_as_login(github_plugin):
+    mock_pr = MagicMock()
+    mock_pr.user.login = "patrick91"
+
+    mock_commit = MagicMock()
+    mock_commit.author.login = "ampagent"
+    mock_commit.commit.message = (
+        "Fix bug\n\nCo-authored-by: Patrick Arminio <patrick.arminio@gmail.com>"
+    )
+    mock_commit.raw_data = {"node_id": "commit-id"}
+    mock_pr.get_commits.return_value = [mock_commit]
+
+    github_plugin.pull_request = mock_pr
+    github_plugin.__dict__["_github"] = MagicMock()
+    github_plugin._github.requester.graphql_query.return_value = (
+        None,
+        {
+            "data": {
+                "node": {
+                    "authors": {
+                        "nodes": [
+                            {"user": {"login": "ampagent"}},
+                            {"user": {"login": "patrick91"}},
+                        ]
+                    }
+                }
+            }
+        },
+    )
+
+    contributors = github_plugin._get_pr_contributors()
+
+    assert contributors == {
+        "pr_author": "patrick91",
+        "additional_contributors": {"ampagent"},
+    }
 
 
 def test_on_release_notes_valid_no_pr_context(github_plugin):


### PR DESCRIPTION
## Summary

- resolve co-authored commit contributors from GitHub's linked commit-author identities
- stop interpreting the first word of a co-author's display name as a username
- exclude co-authors who are already credited as the pull request author
- cover the `Patrick Arminio` / `patrick91` regression

## Testing

- `uv run --frozen pytest -q` — 81 passed
- `uvx ruff@0.9.2 check autopub/plugins/github.py tests/plugins/test_github.py`
- `uvx ruff@0.9.2 format --check autopub/plugins/github.py tests/plugins/test_github.py`
- live contributor lookup for strawberry-graphql/strawberry#4593 returns `patrick91` as the PR author and only `ampagent` as an additional contributor
